### PR TITLE
Adding quotes to line 256 buildrpm.sh

### DIFF
--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -253,7 +253,7 @@ echo "--> Found specfile: $specfile"
 #
 # try to find Libfabric lib subir
 #
-if test -n $libfabric_path; then
+if test -n "$libfabric_path"; then
     # does lib64 exist?
     if test -d $libfabric_path/lib64; then
         # yes, so I will use lib64 as include dir


### PR DESCRIPTION
Added quotes to $libfabric_path on line 256 of contrib\dist\linux\buildrpm.sh

Signed-off-by: Willow Fussell <wmfuss01@louisville.edu>