### PR TITLE
Pr/v5.0.x/build fixes from main

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@ AS_IF([test "$host" != "$target"],
 #
 # Init automake
 #
-AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects no-define 1.13.4 tar-ustar])
+AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects no-define 1.13.4 tar-pax])
 
 # SILENT_RULES is new in AM 1.11, but we require 1.11 or higher via
 # autogen.  Limited testing shows that calling SILENT_RULES directly

--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -253,7 +253,7 @@ echo "--> Found specfile: $specfile"
 #
 # try to find Libfabric lib subir
 #
-if test -n $libfabric_path; then
+if test -n "$libfabric_path"; then
     # does lib64 exist?
     if test -d $libfabric_path/lib64; then
         # yes, so I will use lib64 as include dir


### PR DESCRIPTION
Cherry-picked two commits to correct libfabric_path in contrib/dist/linux/buildrpm.sh and correct tar-ustar to tar-pax in configure.ac.

Signed-off-by: Willow Fussell <wmfuss01@louisville.edu>